### PR TITLE
Use JSON to create labels instead of if/else logic

### DIFF
--- a/js/matchLabels.js
+++ b/js/matchLabels.js
@@ -29,21 +29,21 @@ chrome.extension.sendMessage({}, function(response) {
       var handleMutationEvents = function handleMutationEvents(mutation) {
         Array.prototype.forEach.call(mutation.addedNodes, styleLabelsInNode);
         styleLabelsInNode(mutation.target);
-      }
+      };
 
       var styleLabelsInNode = function styleLabelsInNode(node) {
         if (nodeIsElement(node)) {
           styleLabels(findLabelsInNode(node));
         }
-      }
+      };
 
       var nodeIsElement = function nodeIsElement(node) {
         return (typeof node.querySelectorAll !== 'undefined');
-      }
+      };
 
       var findLabelsInNode = function findLabelsInNode(node) {
         return node.querySelectorAll('a.label');
-      }
+      };
 
       var styleLabels = function styleLabels(labels) {
         Array.prototype.forEach.call(labels, function(label) {

--- a/js/matchLabels.js
+++ b/js/matchLabels.js
@@ -1,3 +1,12 @@
+var LABEL_RULES = {
+  // Define label rules here:
+  // 'label_text': 'label_css_class'
+  'planner': 'planner-label',
+  'needs': 'blocked-label',
+  'investigate': 'attention-label',
+  'live': 'live-label'
+};
+
 chrome.extension.sendMessage({}, function(response) {
   var readyStateCheckInterval = setInterval(function() {
     if (document.readyState === "complete") {
@@ -38,15 +47,11 @@ chrome.extension.sendMessage({}, function(response) {
 
       var styleLabels = function styleLabels(labels) {
         Array.prototype.forEach.call(labels, function(label) {
-          if (label.textContent.match("planner")) {
-            label.classList.add("planner-label");
-          } else if (label.textContent.match("needs")) {
-            label.classList.add("blocked-label");
-          } else if (label.textContent.match("investigate")) {
-            label.classList.add("attention-label");
-          } else if (label.textContent.match("live")) {
-            label.classList.add("live-label");
+          Object.keys(LABEL_RULES).forEach(function(label_rule){
+            if (label.textContent.match(label_rule)) {
+            label.classList.add(LABEL_RULES[label_rule]);
           }
+          });
         });
       }
     }


### PR DESCRIPTION
Hi Carlos,

This pull request contains a change to the j**s/matchLabels.js** file that allows the last few lines which look for label names to refer to a "**list**" of labels instead. The idea here is to separate the code that is '_creating_' the labels, and the code that is '_checking_' the labels. As a bonus, this will make your life easier whenever you to add, or remove, labels as you simply **modify** the JSON instead of the core programming code.

Let me know if you have questions.

-Darius

Example:
```
var LABEL_RULES = {
// Define label rules here:
// 'label_text': 'label_css_class'
'planner': 'planner-label',
'needs': 'blocked-label',
'investigate': 'attention-label',
'live': 'live-label'
};
```

If you're curious, this is via commit https://github.com/okcscott/pivotal-tracker-custom-labels/pull/2/commits/b88507aba2f9d9f0a7789824659edce8cf0cf038
and uses the Object.keys() method to iterate through the JSON object and compare the contents to the labels it finds on the Pivotal Tracker website.